### PR TITLE
patch-build-shim

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -55,7 +55,6 @@ func BuildProject(project common.AppProject, options BuildOptions) error {
 		if err != nil {
 			return err
 		}
-		return nil
 	}
 
 	err = util.ExecCmd(exec.Command("go", "build"), project.SrcDir())


### PR DESCRIPTION
I added `return nil` after `prepareShim` as I was working with Azure Trigger.I was just concerned with building the Docker image and not with the binary itself. Since I was not working with binary, this error went unnoticed. This only came into light when I was messing with cli trigger. We might need to discuss whether we want to build the binaries of the app, which only needs other artifacts.