### PR TITLE
Add an alternate import syntax with better support of Go modules

### DIFF
--- a/api/build.go
+++ b/api/build.go
@@ -81,6 +81,8 @@ func BuildProject(project common.AppProject, options BuildOptions) error {
 		fmt.Println("Path to exe is ", exePath)
 	}
 	if _, err := os.Stat(exePath); err == nil {
+		finalExePath := project.Executable()
+		os.MkdirAll(filepath.Dir(finalExePath), os.ModePerm)
 		err = os.Rename(exePath, project.Executable())
 
 		if err != nil {
@@ -125,7 +127,12 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 				}
 			}
 
-			path, err := project.GetPath(ref)
+			refImport, err := util.NewFlogoImportFromPath(ref)
+			if err != nil {
+				return false, err
+			}
+
+			path, err := project.GetPath(refImport)
 			if err != nil {
 				return false, err
 			}
@@ -205,7 +212,12 @@ func createShimSupportGoFile(project common.AppProject, create bool) error {
 		return nil
 	}
 
-	corePath, err := project.GetPath(flogoCoreRepo)
+	flogoCoreImport, err := util.NewFlogoImportFromPath(flogoCoreRepo)
+	if err != nil {
+		return err
+	}
+
+	corePath, err := project.GetPath(flogoCoreImport)
 	if err != nil {
 		return err
 	}

--- a/api/create.go
+++ b/api/create.go
@@ -149,7 +149,7 @@ func setupAppDirectory(dm util.DepManager, appPath, coreVersion string) error {
 	flogoCoreImport := util.NewFlogoImport(flogoCoreRepo, "", coreVersion, "")
 
 	// add & fetch the core library
-	dm.AddDependency(flogoCoreImport, true)
+	dm.AddDependency(flogoCoreImport)
 
 	return nil
 }
@@ -194,7 +194,7 @@ func importDependencies(project common.AppProject) error {
 			fmt.Printf("%-20s %s\n", instStr, imp)
 		}
 
-		legacy, err := IsLegacySupportRequired(desc, path, imp.ImportPath(), true)
+		legacy, err := IsLegacySupportRequired(desc, path, imp.GoImportPath(), true)
 		if err != nil {
 			return err
 		}

--- a/api/create.go
+++ b/api/create.go
@@ -146,9 +146,10 @@ func setupAppDirectory(dm util.DepManager, appPath, coreVersion string) error {
 
 	fmt.Println("installing core")
 
-	// add & fetch the core library
+	flogoCoreImport := util.NewFlogoImport(flogoCoreRepo, "", coreVersion, "")
 
-	dm.AddDependency(flogoCoreRepo, coreVersion)
+	// add & fetch the core library
+	dm.AddDependency(flogoCoreImport, true)
 
 	return nil
 }
@@ -193,7 +194,7 @@ func importDependencies(project common.AppProject) error {
 			fmt.Printf("%-20s %s\n", instStr, imp)
 		}
 
-		legacy, err := IsLegacySupportRequired(desc, path, imp, true)
+		legacy, err := IsLegacySupportRequired(desc, path, imp.ImportPath(), true)
 		if err != nil {
 			return err
 		}
@@ -211,7 +212,12 @@ func importDependencies(project common.AppProject) error {
 
 func createMain(dm util.DepManager, appDir string) error {
 
-	corePath, err := dm.GetPath(flogoCoreRepo)
+	flogoCoreImport, err := util.NewFlogoImportFromPath(flogoCoreRepo)
+	if err != nil {
+		return err
+	}
+
+	corePath, err := dm.GetPath(flogoCoreImport)
 	if err != nil {
 		return err
 	}
@@ -234,7 +240,12 @@ func getAndUpdateAppJson(dm util.DepManager, appName, appJson string) (string, e
 	if len(appJson) == 0 {
 
 		// appJson wasn't provided, so lets grab the example
-		corePath, err := dm.GetPath(flogoCoreRepo)
+		flogoCoreImport, err := util.NewFlogoImportFromPath(flogoCoreRepo)
+		if err != nil {
+			return "", err
+		}
+
+		corePath, err := dm.GetPath(flogoCoreImport)
 		if err != nil {
 			return "", err
 		}

--- a/api/imports.go
+++ b/api/imports.go
@@ -59,7 +59,12 @@ func registerImport(project common.AppProject, anImport string) error {
 
 func getContribType(project common.AppProject, ref string) (string, error) {
 
-	path, err := project.GetPath(ref)
+	refAsFlogoImport, err := util.NewFlogoImportFromPath(ref)
+	if err != nil {
+		return "", err
+	}
+
+	path, err := project.GetPath(refAsFlogoImport)
 	if err != nil {
 		return "", err
 	}

--- a/api/legacy.go
+++ b/api/legacy.go
@@ -35,7 +35,11 @@ func IsLegacySupportRequired(desc *util.FlogoContribDescriptor, path, pkg string
 }
 
 func InstallLegacySupport(project common.AppProject) error {
-	err := project.AddImports(false, pkgLegacySupport)
+	pkgLegacySupportImport, err := util.NewFlogoImportFromPath(pkgLegacySupport)
+	if err != nil {
+		return err
+	}
+	err = project.AddImports(false, pkgLegacySupportImport)
 	if err == nil {
 		fmt.Println("Installed Legacy Support")
 	}

--- a/common/project.go
+++ b/common/project.go
@@ -9,8 +9,8 @@ type AppProject interface {
 	BinDir() string
 	SrcDir() string
 	Executable() string
-	AddImports(ignoreError bool, imports ...string) error
+	AddImports(ignoreError bool, imports ...util.Import) error
 	RemoveImports(imports ...string) error
-	GetPath(pkg string) (string, error)
+	GetPath(flogoImport util.Import) (string, error)
 	DepManager() util.DepManager
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/project-flogo/cli
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/project-flogo/core v0.9.0-alpha.4.0.20190222151024-3eb86689b764
+	github.com/msoap/byline v1.1.1
+	github.com/project-flogo/core v0.9.0-alpha.4.0.20190225212330-f76237454d56
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/project-flogo/cli
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/project-flogo/core v0.9.0-alpha.4.0.20190220191401-07116138c345
+	github.com/project-flogo/core v0.9.0-alpha.4.0.20190222151024-3eb86689b764
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/project-flogo/cli
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/project-flogo/core v0.9.0-alpha.4.0.20190220191401-07116138c345
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/util/flogo.go
+++ b/util/flogo.go
@@ -87,7 +87,7 @@ func GetContribDescriptor(path string) (*FlogoContribDescriptor, error) {
 }
 
 // ParseAppDescriptor parse the application descriptor
-func GetImports(appJsonPath string) ([]string, error) {
+func GetImports(appJsonPath string) (Imports, error) {
 
 	importSet := make(map[string]struct{})
 
@@ -116,7 +116,16 @@ func GetImports(appJsonPath string) ([]string, error) {
 		allImports = append(allImports, key)
 	}
 
-	return allImports, nil
+	var result Imports
+	for _, i := range allImports {
+		parsedImport, err := ParseImport(i)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, parsedImport)
+	}
+
+	return result, nil
 }
 
 func getImports(appJsonPath string) ([]string, error) {

--- a/util/imports.go
+++ b/util/imports.go
@@ -87,14 +87,14 @@ func (flogoImport *FlogoImport) GoImportPath() string {
 	return flogoImport.modulePath + flogoImport.relativeImportPath
 }
 func (flogoImport *FlogoImport) GoGetImportPath() string {
-	version := "@master"
+	version := "@latest"
 	if flogoImport.version != "" {
 		version = "@" + flogoImport.version
 	}
 	return flogoImport.modulePath + flogoImport.relativeImportPath + version
 }
 func (flogoImport *FlogoImport) GoModImportPath() string {
-	version := "@master"
+	version := "@latest"
 	if flogoImport.version != "" {
 		version = "@" + flogoImport.version
 	}

--- a/util/imports.go
+++ b/util/imports.go
@@ -49,7 +49,7 @@ type Import interface {
 	GoImportPath() string    // the import path used in .go files
 	GoGetImportPath() string // the import path used by "go get" command
 	GoModImportPath() string // the import path used by "go mod edit" command
-	IsLegacy() bool          // an import is "legacy" if it does not have a relative import path
+	IsClassic() bool         // an import is "classic" if it has no : character separator, hence no relative import path
 }
 
 type Imports []Import
@@ -100,7 +100,7 @@ func (flogoImport *FlogoImport) GoModImportPath() string {
 	}
 	return flogoImport.modulePath + version
 }
-func (flogoImport *FlogoImport) IsLegacy() bool {
+func (flogoImport *FlogoImport) IsClassic() bool {
 	return flogoImport.relativeImportPath == ""
 }
 

--- a/util/mod.go
+++ b/util/mod.go
@@ -53,7 +53,7 @@ func (m *ModDepManager) AddDependency(flogoImport Import) error {
 
 	// force resolution
 	// TODO: add a flag to skip download and perform download later (useful in 'flogo create' command for instance)
-	err = ExecCmd(exec.Command("go", "mod", "verify"), m.srcDir)
+	err = ExecCmd(exec.Command("go", "mod", "download", flogoImport.ModulePath()), m.srcDir)
 
 	if err != nil {
 		// if the resolution fails and the Flogo import is "legacy"
@@ -65,8 +65,6 @@ func (m *ModDepManager) AddDependency(flogoImport Import) error {
 
 			err = ExecCmd(exec.Command("go", "get", "-u", flogoImport.GoGetImportPath()), m.srcDir)
 		}
-	} else {
-		err = ExecCmd(exec.Command("go", "mod", "download", flogoImport.ModulePath()), m.srcDir)
 	}
 
 	if err != nil {

--- a/util/mod.go
+++ b/util/mod.go
@@ -63,6 +63,7 @@ func (m *ModDepManager) AddDependency(path, version string, fetch bool) (string,
 		if err != nil {
 			return "", err
 		}
+		return path, nil
 	}
 
 	//note: hack, because go get isn't picking up latest
@@ -72,6 +73,7 @@ func (m *ModDepManager) AddDependency(path, version string, fetch bool) (string,
 		if err != nil {
 			return "", err
 		}
+		return path, nil
 	}
 
 	// use "go mod edit" instead of "go get -u", "go mod verify" will ensure dependencies at the end of imports

--- a/util/mod.go
+++ b/util/mod.go
@@ -56,11 +56,11 @@ func (m *ModDepManager) AddDependency(flogoImport Import) error {
 	err = ExecCmd(exec.Command("go", "mod", "download", flogoImport.ModulePath()), m.srcDir)
 
 	if err != nil {
-		// if the resolution fails and the Flogo import is "legacy"
+		// if the resolution fails and the Flogo import is "classic"
 		// (meaning it does not separate module path from Go import path):
 		// 1. remove the import manually ("go mod edit -droprequire") would fail
 		// 2. try with "go get" instead
-		if flogoImport.IsLegacy() {
+		if flogoImport.IsClassic() {
 			m.RemoveImport(flogoImport)
 
 			err = ExecCmd(exec.Command("go", "get", "-u", flogoImport.GoGetImportPath()), m.srcDir)


### PR DESCRIPTION
# Abstract

This PR improves the way Flogo CLI manage imports of contributions:
* imports can be written with the **classic syntax** or a new **alternate syntax** (see details in project-flogo/core#44) in *flogo.json* file and in ```flogo install``` parameters
* all imports paths currently added in *imports.go* during ```flogo install``` will also be added in *flogo.json* file in imports array.
* Go dependencies are managed with ```go mod``` plumbering when it's possible, with ```go get``` when it's not
* contributions with a version suffix (*@vX.Y.Z*, *\@latest*, \@master, \@feature-branch) can be used with both **classic syntax** and **alternate syntax**

# Requirements

* **For proper serialization of the JSON file (*flogo.json*), this PR requires project-flogo/core#20 to be merged.**
* **Application needs project-flogo/core#44 at runtime so this one is also required to be merged.**

# Tests

## Step-by-step guide

To test this fork with fork from project-flogo/core#20 & project-flogo/core#44:

0. Optionally run following commands in a Go Docker container (successfully tested with Go 1.12.0 as well)
```
docker run --rm -it golang:1.11.5 bash
```

1. Install CLI from this fork with project-flogo/core#20
```
git clone https://github.com/square-it/cli.git /tmp/cli
cd /tmp/cli
git checkout install-contribs-with-version
echo "replace github.com/project-flogo/core => github.com/square-it/core generate-json-schema" >> go.mod
go install ./...
```

2. create an application (choose a. or b.)

a. use updated flogo.json with alternate import syntax from PR project-flogo/core#44 to create a new app (**classic syntax** is obviously still supported, the **only difference** is that **alternate syntax** will use ```go mod``` instead of ```go get``` plumbering)
```
cd /tmp
wget https://raw.githubusercontent.com/square-it/core/new-import-syntax/examples/alt/engine/flogo.json
flogo create app -f flogo.json
```

b. otherwise create directly a standard app with **classic syntax**
```
cd /tmp
flogo create app
```

3. build the application

a. if project was created using new syntax, override *go.mod* to use project-flogo/core#44
```
cd /tmp/app
echo "replace github.com/project-flogo/core => github.com/square-it/core new-import-syntax" >> ./src/go.mod
flogo build -e
```

b. otherwise
```
cd /tmp/app
flogo build -e
```

4. At last, to add a contribution with a version, use for instance:
```
cd /tmp/app
flogo install github.com/square-it/flogo-opentracing-listener@v0.0.2
```

## One-liner test command

The test above can be run with the CLI from master then the CLI from this fork using this command:
```
docker run --rm -it golang:1.11.5 /bin/bash -c "$(wget -q https://gist.githubusercontent.com/debovema/78095d87578c092372037b1dbf05454d/raw/9dba3959add6911065b7e0baf2f20bc5a2b7adfe/test_run.sh -O -)"
```

Details of execution are in [this gist](https://gist.github.com/debovema/78095d87578c092372037b1dbf05454d).