### PR TITLE
Perform a Go mod verify before Go mod download

### DIFF
--- a/util/mod.go
+++ b/util/mod.go
@@ -53,7 +53,10 @@ func (m *ModDepManager) AddDependency(flogoImport Import) error {
 
 	// force resolution
 	// TODO: add a flag to skip download and perform download later (useful in 'flogo create' command for instance)
-	err = ExecCmd(exec.Command("go", "mod", "download", flogoImport.ModulePath()), m.srcDir)
+	err = ExecCmd(exec.Command("go", "mod", "verify"), m.srcDir)
+	if err == nil {
+		err = ExecCmd(exec.Command("go", "mod", "download", flogoImport.ModulePath()), m.srcDir)
+	}
 
 	if err != nil {
 		// if the resolution fails and the Flogo import is "classic"


### PR DESCRIPTION
Doing so will first resolve [pseudo-versions](https://tip.golang.org/cmd/go/#hdr-Pseudo_versions) before doing the actual download.

Fixes #38.