### PR TITLE
Fix create legacy

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -204,7 +204,11 @@ func importDependencies(project common.AppProject) error {
 			return err
 		}
 
-		desc := details.ContribDesc
+		desc, err := util.GetContribDescriptor(path)
+
+		if err != nil {
+			return err
+		}
 
 		if desc != nil {
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,8 @@ require (
 	github.com/msoap/byline v1.1.1
 	github.com/project-flogo/core v0.9.0-rc.2
 	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
+	go.uber.org/atomic v1.4.0 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
 )


### PR DESCRIPTION
Legacy Packages were not being properly installed during the creation of the project.