### PR TITLE
fix rename issues

### DIFF
--- a/commands/pluginhelper.go
+++ b/commands/pluginhelper.go
@@ -105,11 +105,6 @@ func UpdateCLI(pluginPkg string, updateOption int) error {
 		cliExe = cliExe + ".exe"
 	}
 
-	err = util.Rename(exPath)
-	if err != nil {
-		return err
-	}
-
 	err = util.Copy(filepath.Join(cliCmdPath, cliExe), exPath, false)
 	if err != nil {
 		//fmt.Fprintf(os.Stderr, "Error: %v\n", osErr)


### PR DESCRIPTION
Rename caused the new executable file to be renamed to "flogo.old" and created a simple file "flogo" . With this the older "flogo" executable stays and the new executable file is copied in its place 