### PR TITLE
Retrieve version of CLI from Git when building from source

### DIFF
--- a/util/gosrchelper.go
+++ b/util/gosrchelper.go
@@ -22,7 +22,7 @@ func FindOldPackageSrc(pkg string) (srcPath, srcVer string, err error) {
 
 	if _, e := os.Stat(path); !os.IsNotExist(e) {
 		// path/to/whatever exists
-		v := GetPackageVersionOld(pkg)
+		v := GetPackageVersionFromSource(pkg)
 
 		return path, v, nil
 	}


### PR DESCRIPTION
Fixes #113 

Quick test:
```
docker run -it --rm golang

git clone https://github.com/debovema/cli.git
cd cli
git checkout guess-version
go install ./...
```

then using ```flogo --version``` command

gives the following result:
```
flogo cli version 0.9.1-rc.3-8-g64f9e81
```