### PR TITLE
Release engineering: enable Go Releaser on tags in Travis CI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,14 +14,13 @@ builds:
       - GO111MODULE=on
     main: ./cmd/flogo/
     binary: flogo
-
-archive:
-  format: binary
-  replacements:
-    darwin: osx
-    linux: linux
-    windows: win
-    amd64: x86_64
+archives:
+  - format: binary
+    replacements:
+      darwin: osx
+      linux: linux
+      windows: win
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ os:
   - linux
 env:
   - GO111MODULE=on
-install: skip  
+install: skip
 script:
+  - GO111MODULE=off go get ./... # to populate $GOPATH/src for tests
+  - go build ./...
   - go test ./...
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: curl -sL https://git.io/goreleaser | bash
+  on:
+    tags: true
+    condition: $TRAVIS_OS_NAME = linux


### PR DESCRIPTION
While the 0.9.1 is in RC, why not enabling Go Releaser to build binaries and put them in GitHub releases page ?
Based on the branch of this PR I released a [fake version on my repository](https://github.com/debovema/cli/releases/tag/v0.9.99) simply by creating and pushing the v0.9.99 tag. Before that a *GITHUB_TOKEN* environment variable with a [GitHub token](https://github.com/settings/tokens/new) (with ```write:packages``` role) must be [added in Travis CI](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).