### PR TITLE
Fix issue #117 Specify base go.mod for app creation

### DIFF
--- a/api/create.go
+++ b/api/create.go
@@ -14,7 +14,7 @@ import (
 
 var fileSampleEngineMain = filepath.Join("examples", "engine", "main.go")
 
-func CreateProject(basePath, appName, appCfgPath, coreVersion string) (common.AppProject, error) {
+func CreateProject(basePath, appName, appCfgPath, modFilePath, coreVersion string) (common.AppProject, error) {
 
 	var err error
 	var appJson string
@@ -58,7 +58,7 @@ func CreateProject(basePath, appName, appCfgPath, coreVersion string) (common.Ap
 		fmt.Printf("Setting up app directory: %s\n", appDir)
 	}
 
-	err = setupAppDirectory(dm, appDir, coreVersion)
+	err = setupAppDirectory(dm, appDir, modFilePath, coreVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func createAppDirectory(basePath, appName string) (string, error) {
 }
 
 //setupAppDirectory sets up the flogo app directory
-func setupAppDirectory(dm util.DepManager, appPath, coreVersion string) error {
+func setupAppDirectory(dm util.DepManager, appPath, modFilePath, coreVersion string) error {
 
 	err := os.Mkdir(filepath.Join(appPath, dirBin), os.ModePerm)
 	if err != nil {
@@ -140,7 +140,8 @@ func setupAppDirectory(dm util.DepManager, appPath, coreVersion string) error {
 		return err
 	}
 
-	err = dm.Init()
+	// create go.mod only if modFilePath is not specified or the specified file does not exist
+	err = dm.Init(modFilePath)
 	if err != nil {
 		return err
 	}

--- a/api/create_test.go
+++ b/api/create_test.go
@@ -105,7 +105,7 @@ func TestCmdCreate_noflag(t *testing.T) {
 	defer testEnv.cleanup()
 
 	t.Logf("Current dir '%s'", testEnv.currentDir)
-	_, err := CreateProject(testEnv.currentDir, "myApp", "", "")
+	_, err := CreateProject(testEnv.currentDir, "myApp", "", "", "")
 	assert.Equal(t, nil, err)
 
 	_, err = os.Stat(filepath.Join(tempDir, "myApp", "src", "go.mod"))
@@ -140,7 +140,7 @@ func TestCmdCreate_flag(t *testing.T) {
 	}
 	defer file.Close()
 	fmt.Fprintf(file, jsonString)
-	_, err = CreateProject(testEnv.currentDir, "flogo", "flogo.json", "")
+	_, err = CreateProject(testEnv.currentDir, "flogo", "flogo.json", "", "")
 	assert.Equal(t, nil, err)
 
 	_, err = os.Stat(filepath.Join(tempDir, "flogo", "src", "go.mod"))
@@ -169,7 +169,7 @@ func TestCmdCreate_masterCore(t *testing.T) {
 	t.Logf("Current dir '%s'", testEnv.currentDir)
 	os.Chdir(testEnv.currentDir)
 
-	_, err = CreateProject(testEnv.currentDir, "myApp", "", "master")
+	_, err = CreateProject(testEnv.currentDir, "myApp", "", "", "master")
 	assert.Equal(t, nil, err)
 }
 

--- a/api/install_test.go
+++ b/api/install_test.go
@@ -107,7 +107,7 @@ func TestInstallLegacyPkg(t *testing.T) {
 	t.Logf("Current dir '%s'", testEnv.currentDir)
 	_ = os.Chdir(testEnv.currentDir)
 
-	_, err := CreateProject(testEnv.currentDir, "myApp", "", "v0.9.2")
+	_, err := CreateProject(testEnv.currentDir, "myApp", "", "", "v0.9.2")
 
 	assert.Nil(t, err)
 
@@ -138,7 +138,7 @@ func TestInstallPkg(t *testing.T) {
 	t.Logf("Current dir '%s'", testEnv.currentDir)
 	_ = os.Chdir(testEnv.currentDir)
 
-	_, err := CreateProject(testEnv.currentDir, "myApp", "", "")
+	_, err := CreateProject(testEnv.currentDir, "myApp", "", "", "")
 
 	assert.Nil(t, err)
 
@@ -168,7 +168,7 @@ func TestInstallPkgWithVersion(t *testing.T) {
 	t.Logf("Current dir '%s'", testEnv.currentDir)
 	_ = os.Chdir(testEnv.currentDir)
 
-	_, err := CreateProject(testEnv.currentDir, "myApp", "", "")
+	_, err := CreateProject(testEnv.currentDir, "myApp", "", "", "")
 
 	assert.Nil(t, err)
 
@@ -198,7 +198,7 @@ func TestListPkg(t *testing.T) {
 	t.Logf("Current dir '%s'", testEnv.currentDir)
 	_ = os.Chdir(testEnv.currentDir)
 
-	_, err := CreateProject(testEnv.currentDir, "myApp", "", "")
+	_, err := CreateProject(testEnv.currentDir, "myApp", "", "", "")
 
 	assert.Equal(t, nil, err)
 

--- a/api/list_test.go
+++ b/api/list_test.go
@@ -21,7 +21,7 @@ func TestListAllContribs(t *testing.T) {
 	t.Logf("Current dir '%s'", testEnv.currentDir)
 	os.Chdir(testEnv.currentDir)
 
-	_, err := CreateProject(testEnv.currentDir, "myApp", "", "")
+	_, err := CreateProject(testEnv.currentDir, "myApp", "", "", "")
 
 	assert.Equal(t, nil, err)
 
@@ -50,7 +50,7 @@ func TestListWithLegacyPkg(t *testing.T) {
 	}
 	defer file.Close()
 	fmt.Fprintf(file, newJsonString)
-	_, err = CreateProject(testEnv.currentDir, "temp", "flogo.json", "")
+	_, err = CreateProject(testEnv.currentDir, "temp", "flogo.json", "", "")
 	assert.Equal(t, nil, err)
 
 	err = ListContribs(NewAppProject(filepath.Join(testEnv.currentDir, "temp")), true, "")

--- a/api/shim.go
+++ b/api/shim.go
@@ -26,10 +26,9 @@ var fileSampleShimSupport = filepath.Join("examples", "engine", "shim", fileShim
 
 var flogoImportPattern = regexp.MustCompile(`^(([^ ]*)[ ]+)?([^@:]*)@?([^:]*)?:?(.*)?$`)
 
-
 type ShimBuilder struct {
 	appBuilder common.Builder
-	shim string
+	shim       string
 }
 
 func (sb *ShimBuilder) Build(project common.AppProject) error {
@@ -39,7 +38,8 @@ func (sb *ShimBuilder) Build(project common.AppProject) error {
 		return err
 	}
 
-	defer shimCleanup(project)
+	// do not clean up shim source code!
+	//	defer shimCleanup(project)
 
 	err = createShimSupportGoFile(project)
 	if err != nil {

--- a/commands/build.go
+++ b/commands/build.go
@@ -62,7 +62,7 @@ var buildCmd = &cobra.Command{
 			}
 
 			api.SetVerbose(verbose)
-			tempProject, err := api.CreateProject(tempDir, "", flogoJsonFile, "latest")
+			tempProject, err := api.CreateProject(tempDir, "", flogoJsonFile, "", "latest")
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating temp project: %v\n", err)
 				os.Exit(1)

--- a/commands/create.go
+++ b/commands/create.go
@@ -10,10 +10,12 @@ import (
 
 var flogoJsonPath string
 var coreVersion string
+var modFilePath string
 
 func init() {
 	CreateCmd.Flags().StringVarP(&flogoJsonPath, "file", "f", "", "specify a flogo.json to create project from")
 	CreateCmd.Flags().StringVarP(&coreVersion, "cv", "", "", "specify core library version (ex. master)")
+	CreateCmd.Flags().StringVarP(&modFilePath, "mod", "m", "", "go.mod file to override default settings")
 	rootCmd.AddCommand(CreateCmd)
 }
 
@@ -36,7 +38,7 @@ var CreateCmd = &cobra.Command{
 			fmt.Fprintf(os.Stderr, "Error determining working directory: %v\n", err)
 			os.Exit(1)
 		}
-		_, err = api.CreateProject(currentDir, appName, flogoJsonPath, coreVersion)
+		_, err = api.CreateProject(currentDir, appName, flogoJsonPath, modFilePath, coreVersion)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating project: %v\n", err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module github.com/project-flogo/cli
 
+replace go.uber.org/multierr => go.uber.org/multierr v1.6.0
+
 require (
 	github.com/coreos/go-semver v0.2.0
 	github.com/msoap/byline v1.1.1
-	github.com/pkg/errors v0.8.1 // indirect
-	github.com/project-flogo/core v0.9.5-beta.1
+	github.com/project-flogo/core v1.2.0
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 )
 
-go 1.12
+go 1.14


### PR DESCRIPTION
- Implement fix for #117
- when build with `replace` in go.mod, check only lines that start with replace
- keep shim source files after shim build