### PR TITLE
Add shim activity support

### DIFF
--- a/api/shim.go
+++ b/api/shim.go
@@ -85,191 +85,129 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 		return false, err
 	}
 
+	var ref string = ""
+	var triggerFound bool = false
+
 	for _, trgCfg := range descriptor.Triggers {
 
 		if trgCfg.Id != shim {
 			continue 
 		}
 
-		ref := trgCfg.Ref
+		ref, triggerFound = GetAliasRef("flogo:trigger", trgCfg.Ref)
 
-		if trgCfg.Ref != "" {
-			found := false
-			ref, found = GetAliasRef("flogo:trigger", trgCfg.Ref)
-			if !found {
-				return false, fmt.Errorf("unable to determine ref for trigger: %s", trgCfg.Id)
-			}
-		}
-
-		refImport, err := util.NewFlogoImportFromPath(ref)
-		if err != nil {
-			return false, err
-		}
-
-		impPath, err := project.GetPath(refImport)
-		if err != nil {
-			return false, err
-		}
-
-		var shimFilePath string
-
-		shimFilePath = filepath.Join(impPath, dirShim, fileShimGo)
-
-		if _, err := os.Stat(shimFilePath); err == nil {
-
-			err = util.CopyFile(shimFilePath, filepath.Join(project.SrcDir(), fileShimGo))
-			if err != nil {
-				return false, err
-			}
-
-			// Check if this shim based trigger has a gobuild file. If the trigger has a gobuild
-			// execute that file, otherwise check if there is a Makefile to execute
-			goBuildFilePath := filepath.Join(impPath, dirShim, fileBuildGo)
-
-			makefilePath := filepath.Join(shimFilePath, dirShim, fileMakefile)
-
-			if _, err := os.Stat(goBuildFilePath); err == nil {
-				fmt.Println("Using build.go to build shim......")
-
-				err = util.CopyFile(goBuildFilePath, filepath.Join(project.SrcDir(), fileBuildGo))
-				if err != nil {
-					return false, err
-				}
-
-				// Execute go run gobuild.go
-				err = util.ExecCmd(exec.Command("go", "run", fileBuildGo), project.SrcDir())
-				if err != nil {
-					return false, err
-				}
-
-				return true, nil
-			} else if _, err := os.Stat(makefilePath); err == nil {
-				//look for Makefile and execute it
-				fmt.Println("Using make file to build shim...")
-
-				err = util.CopyFile(makefilePath, filepath.Join(project.SrcDir(), fileMakefile))
-				if err != nil {
-					return false, err
-				}
-
-				if Verbose() {
-					fmt.Println("Make File:", makefilePath)
-				}
-
-				// Execute make
-				cmd := exec.Command("make", "-C", project.SrcDir())
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				cmd.Env = util.ReplaceEnvValue(os.Environ(), "GOPATH", project.Dir())
-
-				err = cmd.Run()
-				if err != nil {
-					return false, err
-				}
-
-				return true, nil
-			} else {
-				return false, nil
-			}
-		}
-
-		break
-	}
-
-	for _, resourceCfg := range descriptor.Resources {
-		for _, taskConfig := range resourceCfg.Data.Tasks {
-			if taskConfig.Id != shim {
-				continue
-			}
-
-			ref := taskConfig.Activity.Ref
-
-			if ref != "" {
-				found := false
-				ref, found = GetAliasRef("flogo:activity", ref)
-				if !found {
-					return false, fmt.Errorf("unable to determine ref for trigger: %s", taskConfig.Id)
-				}
-			}
-
-			refImport, err := util.NewFlogoImportFromPath(ref)
-			if err != nil {
-				return false, err
-			}
-	
-			impPath, err := project.GetPath(refImport)
-			if err != nil {
-				return false, err
-			}
-
-			var shimFilePath string
-
-			shimFilePath = filepath.Join(impPath, dirShim, fileShimGo)
-
-			if _, err := os.Stat(shimFilePath); err == nil {
-
-				err = util.CopyFile(shimFilePath, filepath.Join(project.SrcDir(), fileShimGo))
-				if err != nil {
-					return false, err
-				}
-
-				goBuildFilePath := filepath.Join(impPath, dirShim, fileBuildGo)
-
-				makefilePath := filepath.Join(shimFilePath, dirShim, fileMakefile)
-
-				if _, err := os.Stat(goBuildFilePath); err == nil {
-					fmt.Println("Using build.go to build shim......")
-
-					err = util.CopyFile(goBuildFilePath, filepath.Join(project.SrcDir(), fileBuildGo))
-					if err != nil {
-						return false, err
-					}
-
-					// Execute go run gobuild.go
-					err = util.ExecCmd(exec.Command("go", "run", fileBuildGo), project.SrcDir())
-					if err != nil {
-						return false, err
-					}
-
-					return true, nil
-
-				} else if _, err := os.Stat(makefilePath); err == nil {
-
-					//look for Makefile and execute it
-					fmt.Println("Using make file to build shim...")
-
-					err = util.CopyFile(makefilePath, filepath.Join(project.SrcDir(), fileMakefile))
-					if err != nil {
-						return false, err
-					}
-
-					if Verbose() {
-						fmt.Println("Make File:", makefilePath)
-					}
-
-					// Execute make
-					cmd := exec.Command("make", "-C", project.SrcDir())
-					cmd.Stdout = os.Stdout
-					cmd.Stderr = os.Stderr
-					cmd.Env = util.ReplaceEnvValue(os.Environ(), "GOPATH", project.Dir())
-
-					err = cmd.Run()
-					if err != nil {
-						return false, err
-					}
-
-					return true, nil
-					
-				} else {
-					return false, nil
-				}
-			}
-
+		if !triggerFound {
 			break
-		}
+		} 
+		
+		return prepareShimBuildOrMake(project, ref)
+
 	}
 
-	return false, fmt.Errorf("unable to to find shim trigger: %s", shim)
+	if !triggerFound {
+
+		for _, resourceCfg := range descriptor.Resources {
+
+			for _, taskConfig := range resourceCfg.Data.Tasks {
+
+				if taskConfig.Id != shim {
+					continue
+				}
+
+				var found bool
+				ref, found = GetAliasRef("flogo:activity", taskConfig.Activity.Ref)
+				
+				if !found {
+					break
+				} 
+
+				return prepareShimBuildOrMake(project, ref)
+
+			}
+
+		}
+
+	}
+
+	return false, fmt.Errorf("unable to to find shim trigger or activity: %s", shim)
+}
+
+func prepareShimBuildOrMake(project common.AppProject, ref string) (bool, error) {
+
+	refImport, err := util.NewFlogoImportFromPath(ref)
+	if err != nil {
+		return false, err
+	}
+
+	impPath, err := project.GetPath(refImport)
+	if err != nil {
+		return false, err
+	}
+
+	// var shimFilePath string
+
+	// shimFilePath := filepath.Join(impPath, dirShim, fileShimGo)
+	shimDir := filepath.Join(impPath, dirShim)
+
+	// if _, err := os.Stat(shimFilePath); err == nil {
+	if _, err := os.Stat(shimDir); err == nil {
+
+		// err = util.CopyFile(shimFilePath, filepath.Join(project.SrcDir(), fileShimGo))
+		// if err != nil {
+		// 	return false, err
+		// }
+
+		goBuildFilePath := filepath.Join(shimDir, fileBuildGo)
+
+		makefilePath := filepath.Join(shimDir, fileMakefile)
+
+		if _, err := os.Stat(goBuildFilePath); err == nil {
+			fmt.Println("Using build.go to build shim......")
+
+			err = util.CopyFile(goBuildFilePath, filepath.Join(project.SrcDir(), fileBuildGo))
+			if err != nil {
+				return false, err
+			}
+
+			// Execute go run gobuild.go
+			err = util.ExecCmd(exec.Command("go", "run", fileBuildGo), project.SrcDir())
+			if err != nil {
+				return false, err
+			}
+
+			return true, nil
+
+		} else if _, err := os.Stat(makefilePath); err == nil {
+
+			//look for Makefile and execute it
+			fmt.Println("Using make file to build shim...")
+
+			err = util.CopyFile(makefilePath, filepath.Join(project.SrcDir(), fileMakefile))
+			if err != nil {
+				return false, err
+			}
+
+			if Verbose() {
+				fmt.Println("Make File:", makefilePath)
+			}
+
+			// Execute make
+			cmd := exec.Command("make", "-C", project.SrcDir())
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Env = util.ReplaceEnvValue(os.Environ(), "GOPATH", project.Dir())
+
+			err = cmd.Run()
+			if err != nil {
+				return false, err
+			}
+
+			return true, nil
+			
+		} 
+	}
+
+	return  false, nil
 }
 
 func shimCleanup(project common.AppProject) {

--- a/api/shim.go
+++ b/api/shim.go
@@ -86,15 +86,109 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 	}
 
 	for _, trgCfg := range descriptor.Triggers {
-		if trgCfg.Id == shim {
 
-			ref := trgCfg.Ref
+		if trgCfg.Id != shim {
+			continue 
+		}
 
-			if trgCfg.Ref != "" {
+		ref := trgCfg.Ref
+
+		if trgCfg.Ref != "" {
+			found := false
+			ref, found = GetAliasRef("flogo:trigger", trgCfg.Ref)
+			if !found {
+				return false, fmt.Errorf("unable to determine ref for trigger: %s", trgCfg.Id)
+			}
+		}
+
+		refImport, err := util.NewFlogoImportFromPath(ref)
+		if err != nil {
+			return false, err
+		}
+
+		impPath, err := project.GetPath(refImport)
+		if err != nil {
+			return false, err
+		}
+
+		var shimFilePath string
+
+		shimFilePath = filepath.Join(impPath, dirShim, fileShimGo)
+
+		if _, err := os.Stat(shimFilePath); err == nil {
+
+			err = util.CopyFile(shimFilePath, filepath.Join(project.SrcDir(), fileShimGo))
+			if err != nil {
+				return false, err
+			}
+
+			// Check if this shim based trigger has a gobuild file. If the trigger has a gobuild
+			// execute that file, otherwise check if there is a Makefile to execute
+			goBuildFilePath := filepath.Join(impPath, dirShim, fileBuildGo)
+
+			makefilePath := filepath.Join(shimFilePath, dirShim, fileMakefile)
+
+			if _, err := os.Stat(goBuildFilePath); err == nil {
+				fmt.Println("Using build.go to build shim......")
+
+				err = util.CopyFile(goBuildFilePath, filepath.Join(project.SrcDir(), fileBuildGo))
+				if err != nil {
+					return false, err
+				}
+
+				// Execute go run gobuild.go
+				err = util.ExecCmd(exec.Command("go", "run", fileBuildGo), project.SrcDir())
+				if err != nil {
+					return false, err
+				}
+
+				return true, nil
+			} else if _, err := os.Stat(makefilePath); err == nil {
+				//look for Makefile and execute it
+				fmt.Println("Using make file to build shim...")
+
+				err = util.CopyFile(makefilePath, filepath.Join(project.SrcDir(), fileMakefile))
+				if err != nil {
+					return false, err
+				}
+
+				if Verbose() {
+					fmt.Println("Make File:", makefilePath)
+				}
+
+				// Execute make
+				cmd := exec.Command("make", "-C", project.SrcDir())
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				cmd.Env = util.ReplaceEnvValue(os.Environ(), "GOPATH", project.Dir())
+
+				err = cmd.Run()
+				if err != nil {
+					return false, err
+				}
+
+				return true, nil
+			} else {
+				return false, nil
+			}
+		}
+
+		break
+	}
+
+	for _, resourceCfg := range descriptor.Resources {
+		for _, taskConfig := range resourceCfg.Data.Tasks {
+			if taskConfig.Id != shim {
+				continue
+			}
+
+			ref := taskConfig.Activity.Ref
+
+			if ref != "" {
 				found := false
-				ref, found = GetAliasRef("flogo:trigger", trgCfg.Ref)
+				ref, found = GetAliasRef("flogo:activity", ref)
 				if !found {
-					return false, fmt.Errorf("unable to determine ref for trigger: %s", trgCfg.Id)
+					return false, fmt.Errorf("unable to determine ref for trigger: %s", taskConfig.Id)
 				}
 			}
 
@@ -102,7 +196,7 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-
+	
 			impPath, err := project.GetPath(refImport)
 			if err != nil {
 				return false, err
@@ -119,8 +213,6 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 					return false, err
 				}
 
-				// Check if this shim based trigger has a gobuild file. If the trigger has a gobuild
-				// execute that file, otherwise check if there is a Makefile to execute
 				goBuildFilePath := filepath.Join(impPath, dirShim, fileBuildGo)
 
 				makefilePath := filepath.Join(shimFilePath, dirShim, fileMakefile)
@@ -140,7 +232,9 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 					}
 
 					return true, nil
+
 				} else if _, err := os.Stat(makefilePath); err == nil {
+
 					//look for Makefile and execute it
 					fmt.Println("Using make file to build shim...")
 
@@ -165,6 +259,7 @@ func prepareShim(project common.AppProject, shim string) (bool, error) {
 					}
 
 					return true, nil
+					
 				} else {
 					return false, nil
 				}

--- a/commands/build.go
+++ b/commands/build.go
@@ -18,7 +18,7 @@ var syncImport bool
 var flogoJsonFile string
 
 func init() {
-	buildCmd.Flags().StringVarP(&buildShim, "shim", "", "", "use shim trigger")
+	buildCmd.Flags().StringVarP(&buildShim, "shim", "", "", "use shim trigger or activity")
 	buildCmd.Flags().BoolVarP(&buildOptimize, "optimize", "o", false, "optimize build")
 	buildCmd.Flags().BoolVarP(&buildEmbed, "embed", "e", false, "embed configuration in binary")
 	buildCmd.Flags().StringVarP(&flogoJsonFile, "file", "f", "", "specify a flogo.json to build")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,7 +33,7 @@ Flags:
   -e, --embed         embed configuration in binary
   -f, --file string   specify a flogo.json to build
   -o, --optimize      optimize build
-      --shim string   use shim trigger   
+      --shim string   use shim trigger or activity 
 ```
 _**Note:** the optimize flag removes unused trigger, acitons and activites from the built binary._
 

--- a/util/flogo.go
+++ b/util/flogo.go
@@ -27,10 +27,29 @@ type FlogoAppDescriptor struct {
 	Imports     []string `json:"imports"`
 
 	Triggers []*FlogoTriggerConfig `json:"triggers"`
+	Resources []*FlogoResourceConfig `json:"resources"`
 }
 
 type FlogoTriggerConfig struct {
 	Id   string `json:"id"`
 	Ref  string `json:"ref"`
 	Type string `json:"type"`
+}
+
+type FlogoResourceConfig struct {
+	Id   string `json:"id"`
+	Data FlogoResourceDataConfig `json:"data"`
+}
+
+type FlogoResourceDataConfig struct {
+	Tasks []FlogoResourceDataTaskConfig `json:"tasks"`
+}
+
+type FlogoResourceDataTaskConfig struct {
+	Id   string `json:"id"`
+	Activity FlogoResourceDataTaskActivityConfig `json:"activity"`
+}
+
+type FlogoResourceDataTaskActivityConfig struct {
+	Ref  string `json:"ref"`
 }


### PR DESCRIPTION
Changes:

1. Flogo CLI v0.10.0 cannot build shim trigger if trigger shim folder only has build.go so change to detect build.go or makefile instead of checking shim.go exist, e.g. github.com/project-flogo/grpc/trigger/grpc.
2. Add shim activity support to generate client code.   At this moment there is no way to use "flogo build --shim <activity_id>" to generate client code, e.g. github.com/project-flogo/grpc/activity/grpc
3. Current Flogo CLI relies on microgateway to implemtn rest-to-grpc or grpc-to-grpc but this violate gRPC standard using grpc-gateway so Flogo CLI should support grpc-gateway gernation through change #2