### PR TITLE
fix(plugin install): copy executable by renaming instead of create file

### DIFF
--- a/commands/pluginhelper.go
+++ b/commands/pluginhelper.go
@@ -105,7 +105,7 @@ func UpdateCLI(pluginPkg string, updateOption int) error {
 		cliExe = cliExe + ".exe"
 	}
 
-	err = util.Copy(filepath.Join(cliCmdPath, cliExe), exPath, false)
+	err = util.SwapFile(filepath.Join(cliCmdPath, cliExe), exPath)
 	if err != nil {
 		//fmt.Fprintf(os.Stderr, "Error: %v\n", osErr)
 		return err

--- a/util/file.go
+++ b/util/file.go
@@ -172,3 +172,33 @@ func DeleteFile(path string) error {
 
 	return nil
 }
+
+// SwapFile is like a copy but use a temporary file and rename it
+// to allow running executable replacement.
+// Thanks to https://gist.github.com/fenollp/7e31e6462b10c96aef443351bce6aea7
+func SwapFile(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	destDir := filepath.Dir(dst)
+	tmpFile := filepath.Join(destDir, "exe_swap")
+
+	defer DeleteFile(tmpFile)
+
+	data, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(tmpFile, data, srcInfo.Mode()); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpFile, dst); err != nil {
+		return err
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
# Implements
Fix #121 

# Discussion
During refactoring on commit [change plugin build mechanism](https://github.com/project-flogo/cli/commit/64da7b7e1af6308f938d5bd1261539a5157679b8) the new `flogo` executable is **created** instead of **renamed**.

Linux system not allows to update a running executable resulting in error `text file busy`.

The PR insert a `SwapFile` function to allow replacement of running executable (Thanks to @fenollp and his [gist]( https://gist.github.com/fenollp/7e31e6462b10c96aef443351bce6aea7))

# Code references

Old renaming implementation on commits before [change plugin build mechanism](https://github.com/project-flogo/cli/commit/64da7b7e1af6308f938d5bd1261539a5157679b8) :
https://github.com/project-flogo/cli/blob/22cf3e37128c33d6c0bbb5cd90af3cb978a1083b/commands/plugin.go#L267

Actual implementation on master:
Executable copy:
https://github.com/project-flogo/cli/blob/5c3e1e36e17aa2ead2d5774d0ce89b2641107c8f/commands/pluginhelper.go#L108
copyFile function
https://github.com/project-flogo/cli/blob/5c3e1e36e17aa2ead2d5774d0ce89b2641107c8f/util/file.go#L131-L143

